### PR TITLE
Update set of available tool versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,9 +160,8 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`helm`
 
-  * `v3.7.0 <https://github.com/helm/helm/releases/tag/v3.7.1>`__ (default)
-  * `v3.7.0 <https://github.com/helm/helm/releases/tag/v3.7.0>`__
-  * `v3.6.3 <https://github.com/helm/helm/releases/tag/v3.6.3>`__
+  * `v3.8.0 <https://github.com/helm/helm/releases/tag/v3.8.0>`__ (default)
+  * `v3.7.2 <https://github.com/helm/helm/releases/tag/v3.7.2>`__
 
 Rules
 =====

--- a/README.rst
+++ b/README.rst
@@ -155,8 +155,8 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`kustomize`
 
-  * `v4.4.1 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.4.1>`__ (default)
-  * `v4.4.0 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.4.0>`__
+  * `v4.5.0 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.0>`__ (default)
+  * `v4.4.1 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.4.1>`__
 
 * :tool:`helm`
 

--- a/kustomize/private/tools.bzl
+++ b/kustomize/private/tools.bzl
@@ -4,70 +4,48 @@ load(
 )
 
 _helm_releases = {
-    "v3.7.1": [
+    "v3.8.0": [
         {
             "os": "darwin",
             "arch": "amd64",
-            "sha256": "72dc714911e9a1978e1446fedead6c85b777a3972439285fdf2041aeee0ddfb8",
+            "sha256": "532ddd6213891084873e5c2dcafa577f425ca662a6594a3389e288fc48dc2089",
         },
         {
             "os": "linux",
             "arch": "amd64",
-            "sha256": "1fb98a60ba65a47f6c47727fd15eb4bdf31dc5940b41e359759eab707d0f5742",
+            "sha256": "8408c91e846c5b9ba15eb6b1a5a79fc22dd4d33ac6ea63388e5698d1b2320c8b",
         },
         {
             "os": "linux",
             "arch": "arm64",
-            "sha256": "0e2961501ae89936cb03c42bce262df210fb30672422c22ada198252de9d1bc8",
+            "sha256": "23e08035dc0106fe4e0bd85800fd795b2b9ecd9f32187aa16c49b0a917105161",
         },
         {
             "os": "windows",
             "arch": "amd64",
-            "sha256": "413ff349b8c0e643bb99267f903f2f90a125314668207dd9fe1d6aba8ede217f",
+            "sha256": "d52e0cda6c4cc0e0717d5161ca1ba7a8d446437afdbe42b3c565c145ac752888",
         },
     ],
-    "v3.7.0": [
+    "v3.7.2": [
         {
             "os": "darwin",
             "arch": "amd64",
-            "sha256": "0bf671be69563a0c2b4253c393bed271fab90a4aa9321d09685a781f583b5c9d",
+            "sha256": "5a0738afb1e194853aab00258453be8624e0a1d34fcc3c779989ac8dbcd59436",
         },
         {
             "os": "linux",
             "arch": "amd64",
-            "sha256": "096e30f54c3ccdabe30a8093f8e128dba76bb67af697b85db6ed0453a2701bf9",
+            "sha256": "4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e",
         },
         {
             "os": "linux",
             "arch": "arm64",
-            "sha256": "03bf55435b4ebef739f862334bdfbf7b7eed714b94340a22298c485b6626aaca",
+            "sha256": "b0214eabbb64791f563bd222d17150ce39bf4e2f5de49f49fdb456ce9ae8162f",
         },
         {
             "os": "windows",
             "arch": "amd64",
-            "sha256": "cf6dd076898e2dc1e7f4af593d011f99a9de353b6a2d019731dbc254a1ec880e",
-        },
-    ],
-    "v3.6.3": [
-        {
-            "os": "darwin",
-            "arch": "amd64",
-            "sha256": "84a1ff17dd03340652d96e8be5172a921c97825fd278a2113c8233a4e8db5236",
-        },
-        {
-            "os": "linux",
-            "arch": "amd64",
-            "sha256": "07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262",
-        },
-        {
-            "os": "linux",
-            "arch": "arm64",
-            "sha256": "6fe647628bc27e7ae77d015da4d5e1c63024f673062ac7bc11453ccc55657713",
-        },
-        {
-            "os": "windows",
-            "arch": "amd64",
-            "sha256": "797d2abd603a2646f2fb9c3fabba46f2fabae5cbd1eb87c20956ec5b4a2fc634",
+            "sha256": "299165f0af46bece9a61b41305cca8e8d5ec5319a4b694589cd71e6b75aca77e",
         },
     ],
 }
@@ -130,7 +108,7 @@ def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
 
-def helm_register_tool(version = "v3.7.1"):
+def helm_register_tool(version = "v3.8.0"):
     for platform in _helm_releases[version]:
         suffix = "tar.gz"
         if platform["os"] == "windows":

--- a/kustomize/private/tools.bzl
+++ b/kustomize/private/tools.bzl
@@ -8,22 +8,22 @@ _helm_releases = {
         {
             "os": "darwin",
             "arch": "amd64",
-            "sha256": "3a9efe337c61a61b3e160da919ac7af8cded8945b75706e401f3655a89d53ef5",
+            "sha256": "72dc714911e9a1978e1446fedead6c85b777a3972439285fdf2041aeee0ddfb8",
         },
         {
             "os": "linux",
             "arch": "amd64",
-            "sha256": "6cd6cad4b97e10c33c978ff3ac97bb42b68f79766f1d2284cfd62ec04cd177f4",
+            "sha256": "1fb98a60ba65a47f6c47727fd15eb4bdf31dc5940b41e359759eab707d0f5742",
         },
         {
             "os": "linux",
             "arch": "arm64",
-            "sha256": "57875be56f981d11957205986a57c07432e54d0b282624d68b1aeac16be70704",
+            "sha256": "0e2961501ae89936cb03c42bce262df210fb30672422c22ada198252de9d1bc8",
         },
         {
             "os": "windows",
             "arch": "amd64",
-            "sha256": "e057f24032a6b5602edccfdf8fa191568471fce29aada86d6f7f46fc611a3258",
+            "sha256": "413ff349b8c0e643bb99267f903f2f90a125314668207dd9fe1d6aba8ede217f",
         },
     ],
     "v3.7.0": [
@@ -73,6 +73,28 @@ _helm_releases = {
 }
 
 _kustomize_releases = {
+    "v4.5.0": [
+        {
+            "os": "darwin",
+            "arch": "amd64",
+            "sha256": "72dc714911e9a1978e1446fedead6c85b777a3972439285fdf2041aeee0ddfb8",
+        },
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "sha256": "1fb98a60ba65a47f6c47727fd15eb4bdf31dc5940b41e359759eab707d0f5742",
+        },
+        {
+            "os": "linux",
+            "arch": "arm64",
+            "sha256": "0e2961501ae89936cb03c42bce262df210fb30672422c22ada198252de9d1bc8",
+        },
+        {
+            "os": "windows",
+            "arch": "amd64",
+            "sha256": "413ff349b8c0e643bb99267f903f2f90a125314668207dd9fe1d6aba8ede217f",
+        },
+    ],
     "v4.4.1": [
         {
             "os": "darwin",
@@ -94,25 +116,6 @@ _kustomize_releases = {
             "arch": "amd64",
             "sha256": "3e1b11456a81924c16c8df89653ed8597f0c446f9f56628f25f8f1abb2fe0c44",
         },
-    ],
-    "v4.4.0": [
-        {
-            "os": "darwin",
-            "arch": "amd64",
-            "sha256": "f0e55366239464546f9870489cee50764d87ebdd07f7402cf2622e5e8dc77ac1",
-        },
-        {
-            "os": "linux",
-            "arch": "amd64",
-            "sha256": "bf3a0d7409d9ce6a4a393ba61289047b4cb875a36ece1ec94b36924a9ccbaa0f",
-        },
-        {
-            "os": "linux",
-            "arch": "arm64",
-            "sha256": "f38032c5fa58dc05b406702611af82087bc02ba09d450a3c00b217bf94c6f011",
-        },
-        # See https://github.com/kubernetes-sigs/kustomize/issues/4028
-        # for why a Windows build is unavailable for this version.
     ],
 }
 
@@ -147,7 +150,7 @@ filegroup(
             sha256 = platform["sha256"],
         )
 
-def kustomize_register_tool(version = "v4.4.1"):
+def kustomize_register_tool(version = "v4.5.0"):
     for platform in _kustomize_releases[version]:
         _maybe(
             http_archive,

--- a/test/testdata/helm/golden.yaml
+++ b/test/testdata/helm/golden.yaml
@@ -14,7 +14,6 @@ type: Opaque
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: {}
   labels:
     app: test-minecraft
     chart: minecraft-3.1.4

--- a/test/testdata/overlay/golden.yaml
+++ b/test/testdata/overlay/golden.yaml
@@ -8,7 +8,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.4.1
+    app.kubernetes.io/managed-by: kustomize-v4.5.0
   name: translations-t8gcg5kbfg
   namespace: test
 ---
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.4.1
+    app.kubernetes.io/managed-by: kustomize-v4.5.0
   name: show-config
   namespace: test
 spec:


### PR DESCRIPTION
Introduce [_kustomize_ version 4.5.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.0), and make that the default version. Remove version 4.4.0.

Introduce [Helm version 3.8.0](https://github.com/helm/helm/releases/tag/v3.8.0), and make that the default version. Remove versions 3.6.3 and 3.7.1.