### PR TITLE
Update set of available kustomize tool versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,8 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`kustomize`
 
-  * `v4.5.3 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.3>`__ (default)
+  * `v4.5.4 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.4>`__ (default)
+  * `v4.5.3 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.3>`__
   * `v4.5.1 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.1>`__
 
 * :tool:`helm`

--- a/kustomize/private/repositories.bzl
+++ b/kustomize/private/repositories.bzl
@@ -3,39 +3,6 @@ load(
     "http_archive",
 )
 
-def _maybe(repo_rule, name, **kwargs):
-    """Executes the given repository rule if it hasn't been executed already.
-
-    Args:
-      repo_rule: The repository rule to be executed (e.g., `native.git_repository`.)
-      name: The name of the repository to be defined by the rule.
-      **kwargs: Additional arguments passed directly to the repository rule.
-    """
-    if not native.existing_rule(name):
-        repo_rule(name = name, **kwargs)
-
-def _maybe_github_revision(name, organization, repository, revision, extension = "zip", prefix_override = None, uses_v_prefix = False, **kwargs):
-    stripped_prefix = prefix_override
-    if prefix_override == None:
-        prefix_component = revision
-        if uses_v_prefix:
-            prefix_component = prefix_component.lstrip("v")
-        stripped_prefix = "{}-{}".format(repository, prefix_component)
-    _maybe(
-        http_archive,
-        name = name,
-        strip_prefix = stripped_prefix,
-        urls = [
-            "https://github.com/{}/{}/archive/{}.{}".format(
-                organization,
-                repository,
-                revision,
-                extension,
-            ),
-        ],
-        **kwargs
-    )
-
 def kustomize_rules_dependencies():
     http_archive(
         name = "bazel_skylib",

--- a/kustomize/private/tools.bzl
+++ b/kustomize/private/tools.bzl
@@ -51,6 +51,28 @@ _helm_releases = {
 }
 
 _kustomize_releases = {
+    "v4.5.4": [
+        {
+            "os": "darwin",
+            "arch": "amd64",
+            "sha256": "8dfd2648948eac4b1bd996e0c87f6fe3f451db54e265cf42cbadb94b0c56f553",
+        },
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "sha256": "1159c5c17c964257123b10e7d8864e9fe7f9a580d4124a388e746e4003added3",
+        },
+        {
+            "os": "linux",
+            "arch": "arm64",
+            "sha256": "094417546ab9b44ece44f3b31f3170080d0682519144301d5b6be080276a1f34",
+        },
+        {
+            "os": "windows",
+            "arch": "amd64",
+            "sha256": "954dfa7e3fa0b3f86de5b62f0de7ac0e45cc1385eb8694afd2a5a1ac5dcb1e63",
+        },
+    ],
     "v4.5.3": [
         {
             "os": "darwin",
@@ -128,7 +150,7 @@ filegroup(
             sha256 = platform["sha256"],
         )
 
-def kustomize_register_tool(version = "v4.5.3"):
+def kustomize_register_tool(version = "v4.5.4"):
     for platform in _kustomize_releases[version]:
         _maybe(
             http_archive,

--- a/test/testdata/overlay/golden.yaml
+++ b/test/testdata/overlay/golden.yaml
@@ -8,7 +8,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.5.3
+    app.kubernetes.io/managed-by: kustomize-v4.5.4
   name: translations-t8gcg5kbfg
   namespace: test
 ---
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.5.3
+    app.kubernetes.io/managed-by: kustomize-v4.5.4
   name: show-config
   namespace: test
 spec:


### PR DESCRIPTION
Introduce [version 4.5.4](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.4), and make that the default version.