### PR TITLE
Update set of available tool versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,8 +160,8 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`helm`
 
-  * `v3.9.0 <https://github.com/helm/helm/releases/tag/v3.9.0>`__ (default)
-  * `v3.8.1 <https://github.com/helm/helm/releases/tag/v3.8.1>`__
+  * `v3.9.2 <https://github.com/helm/helm/releases/tag/v3.9.2>`__ (default)
+  * `v3.9.0 <https://github.com/helm/helm/releases/tag/v3.9.0>`__
 
 Rules
 =====

--- a/README.rst
+++ b/README.rst
@@ -155,8 +155,8 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`kustomize`
 
-  * `v4.5.5 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.5>`__ (default)
-  * `v4.5.4 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.4>`__
+  * `v4.5.6 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.6>`__ (default)
+  * `v4.5.5 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.5>`__
 
 * :tool:`helm`
 

--- a/kustomize/private/tools.bzl
+++ b/kustomize/private/tools.bzl
@@ -4,6 +4,28 @@ load(
 )
 
 _helm_releases = {
+    "v3.9.2": [
+        {
+            "os": "darwin",
+            "arch": "amd64",
+            "sha256": "35d7ff8bea561831d78dce8f7bf614a7ffbcad3ff88d4c2f06a51bfa51c017e2",
+        },
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "sha256": "3f5be38068a1829670440ccf00b3b6656fd90d0d9cfd4367539f3b13e4c20531",
+        },
+        {
+            "os": "linux",
+            "arch": "arm64",
+            "sha256": "e4e2f9aad786042d903534e3131bc5300d245c24bbadf64fc46cca1728051dbc",
+        },
+        {
+            "os": "windows",
+            "arch": "amd64",
+            "sha256": "d0d98a2a1f4794fcfc437000f89d337dc9278b6b7672f30e164f96c9413a7a74",
+        },
+    ],
     "v3.9.0": [
         {
             "os": "darwin",
@@ -24,28 +46,6 @@ _helm_releases = {
             "os": "windows",
             "arch": "amd64",
             "sha256": "631d333bce5f2274c00af753d54bb62886cdb17a958d2aff698c196612c9e8cb",
-        },
-    ],
-    "v3.8.1": [
-        {
-            "os": "darwin",
-            "arch": "amd64",
-            "sha256": "3b6d87d360a51bf0f2344edd54e3580a8e8de2c4a4fd92eccef3e811f7e81bb3",
-        },
-        {
-            "os": "linux",
-            "arch": "amd64",
-            "sha256": "d643f48fe28eeb47ff68a1a7a26fc5142f348d02c8bc38d699674016716f61cd",
-        },
-        {
-            "os": "linux",
-            "arch": "arm64",
-            "sha256": "dbf5118259717d86c57d379317402ed66016c642cc0d684f3505da6f194b760d",
-        },
-        {
-            "os": "windows",
-            "arch": "amd64",
-            "sha256": "a75003fc692131652d3bd218dd4007692390a1dd156f11fd7668e389bdd8f765",
         },
     ],
 }
@@ -108,7 +108,7 @@ def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
 
-def helm_register_tool(version = "v3.9.0"):
+def helm_register_tool(version = "v3.9.2"):
     for platform in _helm_releases[version]:
         suffix = "tar.gz"
         if platform["os"] == "windows":

--- a/kustomize/private/tools.bzl
+++ b/kustomize/private/tools.bzl
@@ -51,6 +51,28 @@ _helm_releases = {
 }
 
 _kustomize_releases = {
+    "v4.5.6": [
+        {
+            "os": "darwin",
+            "arch": "amd64",
+            "sha256": "76fbaad14142bd532d6a6a7912c6b1e48e427fb20659f172ffd4232d1d430b78",
+        },
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "sha256": "6802d54917eb5887f9c71031c59e6845c1a490c13881b050ea6959b714b4a432",
+        },
+        {
+            "os": "linux",
+            "arch": "arm64",
+            "sha256": "3b66709c7692c5ccfdcb2f4dd383e7aa622b451b046f2197b59033f16457b3b3",
+        },
+        {
+            "os": "windows",
+            "arch": "amd64",
+            "sha256": "4974359500e8315e5e00be6cc65383872723313f96e2cf9f30971d087a2877a5",
+        },
+    ],
     "v4.5.5": [
         {
             "os": "darwin",
@@ -71,28 +93,6 @@ _kustomize_releases = {
             "os": "windows",
             "arch": "amd64",
             "sha256": "a72d7e5bbce1388c829d17208c34bf11df69215e7e496e05d8156a0d44b7de3d",
-        },
-    ],
-    "v4.5.4": [
-        {
-            "os": "darwin",
-            "arch": "amd64",
-            "sha256": "8dfd2648948eac4b1bd996e0c87f6fe3f451db54e265cf42cbadb94b0c56f553",
-        },
-        {
-            "os": "linux",
-            "arch": "amd64",
-            "sha256": "1159c5c17c964257123b10e7d8864e9fe7f9a580d4124a388e746e4003added3",
-        },
-        {
-            "os": "linux",
-            "arch": "arm64",
-            "sha256": "094417546ab9b44ece44f3b31f3170080d0682519144301d5b6be080276a1f34",
-        },
-        {
-            "os": "windows",
-            "arch": "amd64",
-            "sha256": "954dfa7e3fa0b3f86de5b62f0de7ac0e45cc1385eb8694afd2a5a1ac5dcb1e63",
         },
     ],
 }
@@ -128,7 +128,7 @@ filegroup(
             sha256 = platform["sha256"],
         )
 
-def kustomize_register_tool(version = "v4.5.5"):
+def kustomize_register_tool(version = "v4.5.6"):
     for platform in _kustomize_releases[version]:
         _maybe(
             http_archive,

--- a/test/testdata/overlay/golden.yaml
+++ b/test/testdata/overlay/golden.yaml
@@ -8,7 +8,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.5.5
+    app.kubernetes.io/managed-by: kustomize-v4.5.6
   name: translations-t8gcg5kbfg
   namespace: test
 ---
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.5.5
+    app.kubernetes.io/managed-by: kustomize-v4.5.6
   name: show-config
   namespace: test
 spec:


### PR DESCRIPTION
Introduce [_kustomize_ version 4.5.6](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.6), and make that the default version. Remove version 4.5.4.

Introduce [Helm version 3.9.2](https://github.com/helm/helm/releases/tag/v3.9.2), and make that the default version. Remove version 3.8.0.