### PR TITLE
Update set of available kustomize tool versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_kustomize",
-    version = "0.2.0",
+    version = "0.2.1",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,8 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`kustomize`
 
-  * `v4.5.7 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.7>`__ (default)
+  * `v5.0.0 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0>`__ (default)
+  * `v4.5.7 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.7>`__
   * `v4.5.5 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.5>`__
 
 * :tool:`helm`

--- a/kustomize/private/tools/helm/toolchain.bzl
+++ b/kustomize/private/tools/helm/toolchain.bzl
@@ -5,9 +5,11 @@ visibility("public")
 _TOOLS_BY_RELEASE = {
     "v3.11.0": {
         struct(os = "darwin", arch = "amd64"): "5a3d13545a302eb2623236353ccd3eaa01150c869f4d7f7a635073847fd7d932",
+        struct(os = "darwin", arch = "arm64"): "57d36ff801ce8c0201ce9917c5a2d3b4da33e5d4ea154320962c7d6fb13e1f2c",
         struct(os = "linux", arch = "amd64"): "6c3440d829a56071a4386dd3ce6254eab113bc9b1fe924a6ee99f7ff869b9e0b",
         struct(os = "linux", arch = "arm64"): "57d36ff801ce8c0201ce9917c5a2d3b4da33e5d4ea154320962c7d6fb13e1f2c",
         struct(os = "windows", arch = "amd64"): "55477fa4295fb3043835397a19e99a138bb4859fbe7cd2d099de28df9d8786f1",
+        # NB: There is no Windows build available for the ARM64 architecture.
     },
     "v3.10.3": {
         struct(os = "darwin", arch = "amd64"): "77a94ebd37eab4d14aceaf30a372348917830358430fcd7e09761eed69f08be5",

--- a/kustomize/private/tools/kustomize/toolchain.bzl
+++ b/kustomize/private/tools/kustomize/toolchain.bzl
@@ -3,6 +3,14 @@
 visibility("public")
 
 _TOOLS_BY_RELEASE = {
+    "v5.0.0": {
+        struct(os = "darwin", arch = "amd64"): "75bd0e776a1e1c44639aa017bba9b6a305ce7332b89b9e8089e99fee2b83d04a",
+        struct(os = "darwin", arch = "arm64"): "74c576a9d6de9d6abb3e886141635b81e8cf3c2331b011535d4e8b5119f291db",
+        struct(os = "linux", arch = "amd64"): "2e8c28a80ce213528251f489db8d2dcbea7c63b986c8f7595a39fc76ff871cd7",
+        struct(os = "linux", arch = "arm64"): "e97b12a83e7b9b0407cac97cac4c25bc135c42383bd3764d5544e32c96542eca",
+        struct(os = "windows", arch = "amd64"): "19d5e98dbe9a66fc0a75897b6557243c6f9d69c113c1fa4b34c1d3fa892cf74c",
+        struct(os = "windows", arch = "arm64"): "55fe8b00b07b5701a6b537287b54bf0b70db05ffa9b0d7aa8f298256c8da57af",
+    },
     "v4.5.7": {
         struct(os = "darwin", arch = "amd64"): "6fd57e78ed0c06b5bdd82750c5dc6d0f992a7b926d114fe94be46d7a7e32b63a",
         struct(os = "linux", arch = "amd64"): "701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9",
@@ -17,7 +25,7 @@ _TOOLS_BY_RELEASE = {
     },
 }
 
-_DEFAULT_TOOL_VERSION = "v4.5.7"
+_DEFAULT_TOOL_VERSION = "v5.0.0"
 
 def known_release_versions():
     return _TOOLS_BY_RELEASE.keys()

--- a/test/testdata/overlay/golden.yaml
+++ b/test/testdata/overlay/golden.yaml
@@ -8,7 +8,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.5.7
+    app.kubernetes.io/managed-by: kustomize-v5.0.0
   name: translations-t8gcg5kbfg
   namespace: test
 ---
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v4.5.7
+    app.kubernetes.io/managed-by: kustomize-v5.0.0
   name: show-config
   namespace: test
 spec:


### PR DESCRIPTION
Introduce [_kustomize_ version 5.0.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0), and make that the default version. Make the _kustomize_ tool available for more processor architectures, per the available published builds.