### PR TITLE
Set up the "Publish to BCR" GitHub app

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/bisontrails/rules_kustomize",
+    "maintainers": [
+        {
+            "email": "seh@panix.com",
+            "github": "seh",
+            "name": "Steven E. Harris"
+        }
+    ],
+    "repository": [
+        "github:bisontrails/rules_kustomize"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,22 @@
+matrix: &matrix
+  platform:
+  - centos7
+  - debian10
+  - macos
+  - ubuntu2004
+  - windows
+tasks:
+  verify_targets:
+    name: Verify that all tests succeed
+    platform: ${{ platform }}
+    test_targets:
+    - '@rules_kustomize//test:all'
+bcr_test_module:
+  module_path: examples/bzlmod
+  matrix: *matrix
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      build_targets:
+      - //root

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "",
+    "strip_prefix": "{REPO}-{VERSION}",
+    "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}


### PR DESCRIPTION
Mirror releases of this Bazel ruleset to the Bazel Central Registry using [the "Publish to BCR" GitHub app](https://github.com/bazel-contrib/publish-to-bcr), avoiding the need to submit PRs against [the _bazelbuild/bazel-central-registry_ repository](https://github.com/bazelbuild/bazel-central-registry) manually.

See bazelbuild/bazel-central-registry#355 for the basis from which I generalized the template files proposed here.