### PR TITLE
Ensure that tests pass before issuing a release

### DIFF
--- a/.github/actions/build-test/action.yaml
+++ b/.github/actions/build-test/action.yaml
@@ -1,0 +1,44 @@
+name: Build and Test
+description: |
+  Build all eligible Bazel targets and run all available
+  tests, confirming that they all pass.
+runs:
+  using: composite
+  steps:
+  - name: Cache Bazel-related artifacts
+    uses: actions/cache@v3
+    env:
+      cache-name: bazel-cache
+    with:
+      path: |
+        ~/.cache/bazelisk
+        ~/.cache/bazel
+      key: ${{ runner.os }}-${{ env.cache-name }}
+  - name: Install FUSE
+    run: sudo apt install libfuse2
+    shell: bash
+  - name: Install sandboxfs
+    run: |
+      f='./sandboxfs.tar.gz'
+      curl --location --output "${f}" --silent \
+        https://github.com/bazelbuild/sandboxfs/releases/download/sandboxfs-0.2.0/sandboxfs-0.2.0-20200420-linux-x86_64.tgz
+      sudo tar xzv -C /usr/local -f "${f}"
+      rm "${f}"
+    shell: bash
+  - name: Build all Bazel targets
+    run: |
+      bazel build \
+        --experimental_use_sandboxfs \
+        //...
+    shell: bash
+  - name: Test all Bazel targets
+    # Work around https://github.com/bazelbuild/bazel/issues/7470 by
+    # way of the suggestion here:
+    # https://github.com/bazelbuild/bazel/issues/7470#issuecomment-764591831.
+    run: |
+      bazel test \
+        --experimental_use_sandboxfs \
+        --strategy TestRunner=processwrapper-sandbox \
+        --test_output=errors \
+        //...
+    shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out VCS repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Confirm Bazel files is formatted per "buildifier"
       uses: thompsonja/bazel-buildifier@v0.4.0
       with:
@@ -20,38 +20,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Cache bazel-related artifacts
-      uses: actions/cache@v3
-      env:
-        cache-name: bazel-cache
-      with:
-        path: |
-          ~/.cache/bazelisk
-          ~/.cache/bazel
-        key: ${{ runner.os }}-${{ env.cache-name }}
     - name: Check out VCS repository
       uses: actions/checkout@v3
-    - name: Install FUSE
-      run: sudo apt install libfuse2
-    - name: Install sandboxfs
-      run: |
-        f='./sandboxfs.tar.gz'
-        curl --location --output "${f}" --silent \
-          https://github.com/bazelbuild/sandboxfs/releases/download/sandboxfs-0.2.0/sandboxfs-0.2.0-20200420-linux-x86_64.tgz
-        sudo tar xzv -C /usr/local -f "${f}"
-        rm "${f}"
-    - name: Build all Bazel targets
-      run: |
-        bazel build \
-          --experimental_use_sandboxfs \
-          //...
-    - name: Test all Bazel targets
-      # Work around https://github.com/bazelbuild/bazel/issues/7470 by
-      # way of the suggestion here:
-      # https://github.com/bazelbuild/bazel/issues/7470#issuecomment-764591831.
-      run: |
-        bazel test \
-          --experimental_use_sandboxfs \
-          --strategy TestRunner=processwrapper-sandbox \
-          --test_output=errors \
-          //...
+    - name: Build and test all Bazel targets
+      uses: ./.github/actions/build-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - name: Check out VCS repository
       uses: actions/checkout@v3
+    - name: Build and test all Bazel targets
+      uses: ./.github/actions/build-test
     - name: Prepare release notes and artifacts
       run: |
         gh_repository="${{ github.repository }}"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_kustomize",
-    version = "0.2.2",
+    version = "0.0.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")


### PR DESCRIPTION
Don't allow an automated issuance of a GitHub release to proceed upon receiving a pushed Git tag until we're sure that all the Bazel targets build and the tests pass.

While we're here, remove the explicit module version from the  _MODULE.bazel_ file. [The "Publish to BCR" GitHub app](https://github.com/bazel-contrib/publish-to-bcr) will update this value automatically for each release.
