### PR TITLE
Update set of available tool versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ This declaration registers a particular version of the :tool:`helm` and :tool:`k
     kustomize = use_extension("@rules_kustomize//kustomize:extensions.bzl", "kustomize")
     kustomize.download(version = "v5.0.1")
     helm = use_extension("@rules_kustomize//kustomize:extensions.bzl", "helm")
-    helm.download(version = "v3.11.0")
+    helm.download(version = "v3.11.3")
 
 If any number of modules wind up specifying different version values for these tags, the latest version—per :term:`Semantic Versioning` sorting—among the proposed candidate versions wins. If any of the tags also include the :field:`tolerate_newer` attribute with a value of :value:`False`, then no competing version newer than that tag's proposed version can win.
 
@@ -153,10 +153,10 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`helm`
 
-  * `v3.11.3 <https://github.com/helm/helm/releases/tag/v3.11.3>`__ (default)
+  * `v3.12.1 <https://github.com/helm/helm/releases/tag/v3.12.1>`__ (default)
+  * `v3.11.3 <https://github.com/helm/helm/releases/tag/v3.11.3>`__
   * `v3.11.2 <https://github.com/helm/helm/releases/tag/v3.11.2>`__
   * `v3.11.0 <https://github.com/helm/helm/releases/tag/v3.11.0>`__
-  * `v3.10.3 <https://github.com/helm/helm/releases/tag/v3.10.3>`__
 
 Rules
 =====

--- a/README.rst
+++ b/README.rst
@@ -122,16 +122,16 @@ In order to use these rules in your Bazel project, you must instruct Bazel to do
 
 .. code:: bazel
 
-    bazel_dep(name = "rules_kustomize", version = "0.3.3")
+    bazel_dep(name = "rules_kustomize", version = "0.3.4")
 
 This declaration registers a particular version of the :tool:`helm` and :tool:`kustomize` tools, respectively. By default, it registers `the latest version known to the rules <Tool Versions_>`_. You can specify a preferred version for each tool by supplying the known version slug (e.g. "v4.5.7") as an argument to the respective module extension's :field:`download` tag.
 
 .. code:: bazel
 
-    bazel_dep(name = "rules_kustomize", version = "0.3.3")
+    bazel_dep(name = "rules_kustomize", version = "0.3.4")
 
     kustomize = use_extension("@rules_kustomize//kustomize:extensions.bzl", "kustomize")
-    kustomize.download(version = "v5.0.1")
+    kustomize.download(version = "v5.0.3")
     helm = use_extension("@rules_kustomize//kustomize:extensions.bzl", "helm")
     helm.download(version = "v3.11.3")
 
@@ -146,10 +146,10 @@ At present, these rules can load the following versions of these tools:
 
 * :tool:`kustomize`
 
-  * `v5.0.3 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.3>`__ (default)
+  * `v5.1.0 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.1.0>`__ (default)
+  * `v5.0.3 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.3>`__
   * `v5.0.1 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.1>`__
   * `v5.0.0 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0>`__
-  * `v4.5.7 <https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.5.7>`__
 
 * :tool:`helm`
 

--- a/kustomize/private/tools/helm/toolchain.bzl
+++ b/kustomize/private/tools/helm/toolchain.bzl
@@ -3,6 +3,14 @@
 visibility("public")
 
 _TOOLS_BY_RELEASE = {
+    "v3.12.1": {
+        struct(os = "darwin", arch = "amd64"): "f487b5d8132bd2091378258a3029e33ee10f71575b2167cdfeaf6d0144d20938",
+        struct(os = "darwin", arch = "arm64"): "e82e0433589b1b5170807d6fec75baedba40620458510bbd30cdb9d2246415fe",
+        struct(os = "linux", arch = "amd64"): "1a7074f58ef7190f74ce6db5db0b70e355a655e2013c4d5db2317e63fa9e3dea",
+        struct(os = "linux", arch = "arm64"): "50548d4fedef9d8d01d1ed5a2dd5c849271d1017127417dc4c7ef6777ae68f7e",
+        struct(os = "windows", arch = "amd64"): "9040f8f37c90600a51db4934c04bc9c2adc058cb2161e20b5193b3ba46de10fa",
+        # NB: There is no Windows build available for the ARM64 architecture.
+    },
     "v3.11.3": {
         struct(os = "darwin", arch = "amd64"): "9d029df37664b50e427442a600e4e065fa75fd74dac996c831ac68359654b2c4",
         struct(os = "darwin", arch = "arm64"): "267e4d50b68e8854b9cc44517da9ab2f47dec39787fed9f7eba42080d61ac7f8",
@@ -27,16 +35,9 @@ _TOOLS_BY_RELEASE = {
         struct(os = "windows", arch = "amd64"): "55477fa4295fb3043835397a19e99a138bb4859fbe7cd2d099de28df9d8786f1",
         # NB: There is no Windows build available for the ARM64 architecture.
     },
-    "v3.10.3": {
-        struct(os = "darwin", arch = "amd64"): "77a94ebd37eab4d14aceaf30a372348917830358430fcd7e09761eed69f08be5",
-        struct(os = "darwin", arch = "arm64"): "4f3490654349d6fee8d4055862efdaaf9422eca1ffd2a15393394fd948ae3377",
-        struct(os = "linux", arch = "amd64"): "950439759ece902157cf915b209b8d694e6f675eaab5099fb7894f30eeaee9a2",
-        struct(os = "linux", arch = "arm64"): "260cda5ff2ed5d01dd0fd6e7e09bc80126e00d8bdc55f3269d05129e32f6f99d",
-        struct(os = "windows", arch = "amd64"): "5d97aa26830c1cd6c520815255882f148040587fd7cdddb61ef66e4c081566e0",
-    },
 }
 
-_DEFAULT_TOOL_VERSION = "v3.11.3"
+_DEFAULT_TOOL_VERSION = "v3.12.1"
 
 def known_release_versions():
     return _TOOLS_BY_RELEASE.keys()

--- a/kustomize/private/tools/kustomize/toolchain.bzl
+++ b/kustomize/private/tools/kustomize/toolchain.bzl
@@ -3,6 +3,14 @@
 visibility("public")
 
 _TOOLS_BY_RELEASE = {
+    "v5.1.0": {
+        struct(os = "darwin", arch = "amd64"): "08664a17820138a68b7cbe302b1b63f4ec19c6e0838385f789ee0470f026ba25",
+        # NB: There is no Darwin build available for the ARM64 architecture.
+        struct(os = "linux", arch = "amd64"): "52f4cf1ba34d38fd55a9bef819e329c9a4561f5f57f8f539346038ab5026dda8",
+        struct(os = "linux", arch = "arm64"): "4e333ccf092bb72ef5d6bfd3e1f8abb161b5540ce47a53474d70c58eeb99f0a9",
+        struct(os = "windows", arch = "amd64"): "ac48286444a33417e5251393f1b1b9972b00cff82fd3ab8d21ca8d8c29411199",
+        # NB: There is no Windows build available for the ARM64 architecture.
+    },
     "v5.0.3": {
         struct(os = "darwin", arch = "amd64"): "a3300ccc81ed8e7df415f3537b49e70d89f985a28c9ade8a885ebf6f1689b4e0",
         struct(os = "darwin", arch = "arm64"): "ecb15ba64356507f8c73796acbe79b445c17f637963b05be72a905c05f6abfc1",
@@ -27,15 +35,9 @@ _TOOLS_BY_RELEASE = {
         struct(os = "windows", arch = "amd64"): "19d5e98dbe9a66fc0a75897b6557243c6f9d69c113c1fa4b34c1d3fa892cf74c",
         struct(os = "windows", arch = "arm64"): "55fe8b00b07b5701a6b537287b54bf0b70db05ffa9b0d7aa8f298256c8da57af",
     },
-    "v4.5.7": {
-        struct(os = "darwin", arch = "amd64"): "6fd57e78ed0c06b5bdd82750c5dc6d0f992a7b926d114fe94be46d7a7e32b63a",
-        struct(os = "linux", arch = "amd64"): "701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9",
-        struct(os = "linux", arch = "arm64"): "65665b39297cc73c13918f05bbe8450d17556f0acd16242a339271e14861df67",
-        struct(os = "windows", arch = "amd64"): "79af25f97bb10df999e540def94e876555696c5fe42d4c93647e28f83b1efc55",
-    },
 }
 
-_DEFAULT_TOOL_VERSION = "v5.0.3"
+_DEFAULT_TOOL_VERSION = "v5.1.0"
 
 def known_release_versions():
     return _TOOLS_BY_RELEASE.keys()

--- a/test/testdata/overlay/golden.yaml
+++ b/test/testdata/overlay/golden.yaml
@@ -8,7 +8,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v5.0.3
+    app.kubernetes.io/managed-by: kustomize-v5.1.0
   name: translations-t8gcg5kbfg
   namespace: test
 ---
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v5.0.3
+    app.kubernetes.io/managed-by: kustomize-v5.1.0
   name: show-config
   namespace: test
 spec:


### PR DESCRIPTION
Introduce [_kustomize_ version 5.1.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize/v5.1.0), and make that the default version. Remove version 4.5.7.

Introduce [Helm version 3.12.1](https://github.com/helm/helm/releases/tag/v3.12.1), and make that the default version. Remove version 3.10.3.
